### PR TITLE
Video database broke because of missing dependency avprobe.

### DIFF
--- a/Code/process_video.py
+++ b/Code/process_video.py
@@ -66,7 +66,7 @@ def process_videos(video_list, indx):
         frame_rate = get_frame_rate(video) 
         total_frames = get_frame_count(video)
         total_audio_frames = get_frame_count_audio(video)
-
+        
         # get corresponding audio file
         filename, fileExtension = os.path.splitext(video)
         audio = filename + '.wav'
@@ -83,7 +83,7 @@ def process_videos(video_list, indx):
         frame_nbr = 0
         while(cap.isOpened()):
             ret, frame = cap.read()
-            if frame == None:
+            if not ret:
                 break
             audio_frame = frame_to_audio(frame_nbr, frame_rate, fs, wav_data)
 
@@ -95,14 +95,14 @@ def process_videos(video_list, indx):
                 mfccs.append(ceps)
                 
             # calculate sum of differences
-            if not prev_frame == None:
+            if not prev_frame is None:
                 tdiv = temporal_diff(prev_frame, frame, 10)
                 #diff = np.absolute(prev_frame - frame)
                 #sum = np.sum(diff.flatten()) / (diff.shape[0]*diff.shape[1]*diff.shape[2])
                 sum_of_differences.append(tdiv)
             colorhist = ft.colorhist(frame)
             colorhists.append(colorhist)
-            if not prev_colorhist == None:
+            if not prev_colorhist is None:
                 ch_diff = colorhist_diff(prev_colorhist, colorhist)
                 colorhist_diffs.append(ch_diff)
             prev_colorhist = colorhist
@@ -145,6 +145,5 @@ for type_ in video_types:
 # create database
 indx = create_database()
 process_videos(video_list,indx)
-
 
 

--- a/Code/video_tools.py
+++ b/Code/video_tools.py
@@ -8,25 +8,25 @@ def video_info(video, util):
     out, err = process.communicate()
     return out
 
-def get_duration(video, util='avprobe'):
+def get_duration(video, util='ffprobe'):
     info = video_info(video, util)
     pattern = 'codec_type\=video.*?duration\=(\d+[\/\d.]*|\d)'
     result = re.search(pattern, info, re.DOTALL).group(1)
     return float(result)
 
-def get_frame_rate(video, util='avprobe'):
+def get_frame_rate(video, util='ffprobe'):
     info = video_info(video, util)
     pattern = 'codec_type\=video.*?avg_frame_rate\=(\d+[\/\d.]*|\d)'
     result = re.search(pattern, info, re.DOTALL).group(1)
     return float(Fraction(result))
 
-def get_frame_count(video, util='avprobe'):
+def get_frame_count(video, util='ffprobe'):
     info = video_info(video, util)
     pattern = 'codec_type\=video.*?nb_frames\=([0-9]+)'
     result = re.search(pattern, info, re.DOTALL)
     return int(result.group(1))
 
-def get_frame_count_audio(video, util='avprobe'):
+def get_frame_count_audio(video, util='ffprobe'):
     info = video_info(video, util)
     pattern = 'codec_type\=audio.*?nb_frames\=([0-9]+)'
     result = re.search(pattern, info, re.DOTALL)
@@ -36,5 +36,4 @@ def frame_to_audio(frame_nbr, frame_rate, fs, audio):
     start_index = int(frame_nbr / frame_rate * fs)
     end_index = int((frame_nbr+1) / frame_rate * fs)
     return audio[start_index:end_index]
-
 


### PR DESCRIPTION
*video_tools.py: Now uses ffprobe as opposed to avprobe. They have the same syntax. 
Students do need to (know to) install ffmpeg using: apt-get install ffmpeg.
*process_video.py: Changed == comparisons to use "is" keyword. It lead to errors after fixing the ffprobe calls